### PR TITLE
Remove duplicate hash key

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -46,7 +46,6 @@ class Premailer
   # source: http://stackoverflow.com/questions/2812781/how-to-convert-webpage-apostrophe-8217-to-ascii-39-in-ruby-1-
   HTML_ENTITIES = {
     "1.8" => {
-      "\342\200\231" => "'",
       "\342\200\246" => "...",
       "\342\200\176" => "'",
       "\342\200\177" => "'",


### PR DESCRIPTION
Fix this warning in our app:

```
lib/premailer/premailer.rb:49: warning: duplicated key at line 54 ignored: "’"
```
